### PR TITLE
Fix README with incorrect pip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project contains tools to generate C code for packing DroneCAN messages.
 
 ## Dependencies
-* `pip install em`
+* `pip install empy`
 * `pip install pexpect`
 
 ## How To Use


### PR DESCRIPTION
README lists the incorrect pip package dependency for EmPy templating module. Any errors from installing the wrong package are initially hidden due to multiprocessing pool.

Packages in question:
EmPy: https://pypi.org/project/empy/
Em (wrong package): https://pypi.org/project/em/