### PR TITLE
dronecan_dsdlc: print result stacktraces on incomplete build

### DIFF
--- a/dronecan_dsdlc.py
+++ b/dronecan_dsdlc.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
         buildlist = set()
         for msg_name in [msg.full_name for msg in messages]:
             buildlist.add(msg_name)
-            print('expanding %s' % (msg_name,))
+            # print('expanding %s' % (msg_name,))
             # expand_message(msg_name)
             # append_builtlist(msg_name)
             results.append(pool.apply_async(expand_message, (msg_name,), callback=append_builtlist))


### PR DESCRIPTION
This caused Tom some pain as he had a module `em` installed as well as `empy`.  The former doesn't have a method that we need, apparently.

The use of `multiprocessing.pool` mean that we were swallowing and throwing away the exceptions, which made this *much* harder to track down than it should have been.  So stop throwing them away, and provide a hint to the user as to what might fix their problem.
