### PR TITLE
Dynamic compound array decode fixes

### DIFF
--- a/templates/msg.h.em
+++ b/templates/msg.h.em
@@ -205,8 +205,8 @@ void _@(msg_underscored_name)_decode(const CanardRxTransfer* transfer, uint32_t*
 
 @(ind)if (tao) {
 @{indent += 1}@{ind = '    '*indent}@
-msg->@(field.name).len = 0;
-@(ind)while (((transfer->payload_len*8)-*bit_ofs) > 0) {
+@(ind)msg->@(field.name).len = 0;
+@(ind)while ((transfer->payload_len*8) > *bit_ofs) {
 @{indent += 1}@{ind = '    '*indent}@
 @(ind)_@(underscored_name(field.type.value_type))_decode(transfer, bit_ofs, &msg->@(field_get_data(field))[msg->@(field.name).len], @[if field == msg_fields[-1] and field.type.value_type.get_min_bitlen() < 8]tao && i==msg->@(field.name).len@[else]false@[end if]@);
 @(ind)msg->@(field.name).len++;

--- a/templates/msg.h.em
+++ b/templates/msg.h.em
@@ -202,6 +202,7 @@ void _@(msg_underscored_name)_decode(const CanardRxTransfer* transfer, uint32_t*
 
 @[          end if]@
 @[              if field.type.value_type.category == field.type.value_type.CATEGORY_COMPOUND]@
+@[                  if field == msg_fields[-1] and field.type.value_type.get_min_bitlen() >= 8]@
 
 @(ind)if (tao) {
 @{indent += 1}@{ind = '    '*indent}@
@@ -214,6 +215,9 @@ void _@(msg_underscored_name)_decode(const CanardRxTransfer* transfer, uint32_t*
 @(ind)}
 @{indent -= 1}@{ind = '    '*indent}@
 @(ind)} else {
+@[                  else]@
+@(ind){
+@[                  end if]@
 @{indent += 1}@{ind = '    '*indent}@
 @[              end if]@
 @(ind)for (size_t i=0; i < msg->@(field.name).len; i++) {


### PR DESCRIPTION
This changes the message decode template so that tail-array-optimization is applied correctly to dynamic length arrays of compound type. Previously TAO would be attempted even if the array was not the last field in data structure.
