### PR TITLE
fixed check for valid length for CANFD

### DIFF
--- a/templates/msg.c.em
+++ b/templates/msg.c.em
@@ -28,6 +28,9 @@ uint32_t @(msg_underscored_name)_encode(@(msg_c_type)* msg, uint8_t* buffer
     return ((bit_ofs+7)/8);
 }
 
+/*
+  return true if the decode is invalid
+ */
 bool @(msg_underscored_name)_decode(const CanardRxTransfer* transfer, @(msg_c_type)* msg) {
     uint32_t bit_ofs = 0;
     _@(msg_underscored_name)_decode(transfer, &bit_ofs, msg, 
@@ -38,7 +41,15 @@ bool @(msg_underscored_name)_decode(const CanardRxTransfer* transfer, @(msg_c_ty
 #endif
     );
 
-    return (((bit_ofs+7)/8) != transfer->payload_len);
+    const uint32_t byte_len = (bit_ofs+7U)/8U;
+#if CANARD_ENABLE_TAO_OPTION
+    // if this could be CANFD then the dlc could indicating more bytes than
+    // we actually have
+    if (!transfer->tao) {
+        return byte_len > transfer->payload_len;
+    }
+#endif
+    return byte_len != transfer->payload_len;
 }
 
 #ifdef CANARD_DSDLC_TEST_BUILD


### PR DESCRIPTION
the dlc on CANFD packets is quantised so payload_len may be larger than the byte length of the message
Note that ideally we would do the dlc rounding and accept either the payload_len or dlc_roundup(payload_len), but this should be sufficient
