### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -17,5 +17,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dsdl_generated
-          path: dsdl_generated
+          path: |
+            tests/dsdl_generated/include/dronecan_msgs.h
+            tests/dsdl_generated/include/uavcan.Timestamp.h
+            tests/dsdl_generated/src/uavcan.Timestamp.c
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/test_regression.yml
+++ b/.github/workflows/test_regression.yml
@@ -16,3 +16,15 @@ jobs:
         shell: bash
         run: |
           tests/test_regression.sh
+
+      - name: Archive generated headers
+        uses: actions/upload-artifact@v3
+        with:
+          name: dsdl_generated
+          path: |
+            tests/dsdl_generated/include/dronecan_msgs.h
+            tests/dsdl_generated/include/uavcan.Timestamp.h
+            tests/dsdl_generated/src/uavcan.Timestamp.o
+            tests/dsdl_generated/src/uavcan.Timestamp.c
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -16,5 +16,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dsdl_generated
-          path: dsdl_generated
+          path: |
+            tests/dsdl_generated/include/dronecan_msgs.h
+            tests/dsdl_generated/include/uavcan.Timestamp.h
+            tests/dsdl_generated/src/uavcan.Timestamp.c
+          if-no-files-found: error
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ target/
 
 #history
 .history
+
+# Testing files
+tests/DSDL/
+tests/dsdl_generated/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,6 @@ target/
 .history
 
 # Testing files
-tests/DSDL/
-tests/dsdl_generated/
-.venv/
+DSDL
+dsdl_generated
+libcanard

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ To run the test simply execute the following command
 python dronecan_dsdlc/dronecan_dsdlc.py -O <output directory> <list of namespace dirs> --run-test
 ```
 
-Some tests are available in the './tests' folder. Run them to test your environment.
+Some tests are available in the 'tests' folder. Run them to test your environment.
 
 ```
-# Windows
-cd tests
-./test_windows.cmd
+# Linux
+./tests/test_linux.sh
 
+# Linux (Run regression test)
+./tests/test_regression.sh
+
+# Windows
+.\tests\test_windows.cmd
 ```

--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 This project contains tools to generate C code for packing DroneCAN messages.
 
 ## Dependencies
-* `pip install empy`
-* `pip install pexpect`
+* `pip install -r requirements.txt` 
 
 ## How To Use
 
-To generate C code please ensure that you have https://github.com/dronecan/pydronecan https://github.com/dronecan/DSDL 
-https://github.com/dronecan/libcanard cloned alongside this project. Then run the following 
-command:
+To generate C code please ensure that you have these cloned alongside this project. 
+```
+https://github.com/dronecan/pydronecan 
+https://github.com/dronecan/DSDL 
+https://github.com/dronecan/libcanard 
+```
+
+Then run the following command:
 ```
 python dronecan_dsdlc/dronecan_dsdlc.py -O <output directory> <list of namespace dirs>
 # e.g. python dronecan_dsdlc/dronecan_dsdlc.py -O dsdlc_generated libraries/AP_UAVCAN/dsdl/ardupilot DSDL/uavcan
@@ -20,4 +24,13 @@ To run the test simply execute the following command
 
 ```
 python dronecan_dsdlc/dronecan_dsdlc.py -O <output directory> <list of namespace dirs> --run-test
+```
+
+Some tests are available in the './tests' folder. Run them to test your environment.
+
+```
+# Windows
+cd tests
+./test_windows.cmd
+
 ```

--- a/dronecan_dsdlc_helpers.py
+++ b/dronecan_dsdlc_helpers.py
@@ -13,7 +13,7 @@ import em
 import math
 import copy
 sys.path.insert(0, os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "../pydronecan/"))
+    os.path.dirname(os.path.realpath(__file__)), "./tests/pydronecan/"))
 import dronecan
 
 class bcolors:
@@ -247,7 +247,7 @@ def msg_test_makefile_name_response(obj):
     return 'test_%s_response.mk' % (obj.full_name,)
 
 def get_canard_src():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'libcanard/canard.c'))
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '.', 'tests/libcanard/canard.c'))
 
 def get_canard_inc():
     return os.path.dirname(get_canard_src())

--- a/dronecan_dsdlc_tester.py
+++ b/dronecan_dsdlc_tester.py
@@ -11,7 +11,7 @@ import sys
 import subprocess
 import pexpect
 sys.path.insert(0, os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "../pydronecan/"))
+    os.path.dirname(os.path.realpath(__file__)), "./tests/pydronecan/"))
 import dronecan
 
 from dronecan_dsdlc_helpers import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+dronecan==1.0.25
+empy==3.3.4
+pexpect==4.9.0
+ptyprocess==0.7.0
+pydronecan==0.0
+setuptools==69.0.2

--- a/tests/test_linux.sh
+++ b/tests/test_linux.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 # simple test of DSDL compilation for linux
+# Tested on python 3.11.4
 
 set -e
 set -x
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PYENV=$SCRIPT_DIR/.pyenv
+
+# Set python executable for your environment here
+PY=python3
+
+# Python virtual environment
+$PY -m venv $PYENV
+source $PYENV/bin/activate
+
 # test compiler on linux
-python3 -m pip install -U empy pexpect dronecan
-rm -rf DSDL
-git clone https://github.com/DroneCAN/DSDL
+$PY -m pip install -r requirements.txt
+rm -rf $SCRIPT_DIR/DSDL
+
+git clone https://github.com/DroneCAN/DSDL $SCRIPT_DIR/DSDL
 
 echo "Testing generation"
-python3 dronecan_dsdlc.py --output dsdl_generated DSDL/dronecan DSDL/uavcan DSDL/com DSDL/ardupilot 
+$PY dronecan_dsdlc.py --output $SCRIPT_DIR/dsdl_generated $SCRIPT_DIR/DSDL/dronecan $SCRIPT_DIR/DSDL/uavcan $SCRIPT_DIR/DSDL/com tests/DSDL/ardupilot 

--- a/tests/test_regression.sh
+++ b/tests/test_regression.sh
@@ -4,12 +4,23 @@
 set -e
 set -x
 
-# test compiler on linux
-python3 -m pip install -U empy pexpect dronecan
-rm -rf DSDL
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PYENV=$SCRIPT_DIR/.pyenv
 
-git clone https://github.com/DroneCAN/DSDL
-(cd .. && git clone https://github.com/DroneCAN/libcanard)
+# Set python executable for your environment here
+PY=python3
+
+# Python virtual environment
+$PY -m venv $PYENV
+source $PYENV/bin/activate
+
+# test compiler on linux
+$PY -m pip install -r requirements.txt
+rm -rf $SCRIPT_DIR/DSDL
+rm -rf $SCRIPT_DIR/libcanard
+
+git clone https://github.com/DroneCAN/DSDL $SCRIPT_DIR/DSDL
+git clone https://github.com/DroneCAN/libcanard $SCRIPT_DIR/libcanard
 
 echo "Testing generation with regression testing"
-python3 dronecan_dsdlc.py --output dsdl_generated DSDL/dronecan DSDL/uavcan DSDL/com DSDL/ardupilot --run-test
+$PY dronecan_dsdlc.py --output $SCRIPT_DIR/dsdl_generated $SCRIPT_DIR/DSDL/dronecan $SCRIPT_DIR/DSDL/uavcan $SCRIPT_DIR/DSDL/com $SCRIPT_DIR/DSDL/ardupilot --run-test

--- a/tests/test_regression.sh
+++ b/tests/test_regression.sh
@@ -18,9 +18,11 @@ source $PYENV/bin/activate
 $PY -m pip install -r requirements.txt
 rm -rf $SCRIPT_DIR/DSDL
 rm -rf $SCRIPT_DIR/libcanard
+rm -rf $SCRIPT_DIR/pydronecan
 
 git clone https://github.com/DroneCAN/DSDL $SCRIPT_DIR/DSDL
 git clone https://github.com/DroneCAN/libcanard $SCRIPT_DIR/libcanard
+git clone https://github.com/DroneCAN/pydronecan $SCRIPT_DIR/pydronecan
 
 echo "Testing generation with regression testing"
 $PY dronecan_dsdlc.py --output $SCRIPT_DIR/dsdl_generated $SCRIPT_DIR/DSDL/dronecan $SCRIPT_DIR/DSDL/uavcan $SCRIPT_DIR/DSDL/com $SCRIPT_DIR/DSDL/ardupilot --run-test

--- a/tests/test_windows.cmd
+++ b/tests/test_windows.cmd
@@ -2,20 +2,23 @@
 @REM Simple test of DSDL compilation for windows
 @REM Tested on python 3.12.0
 
+set SCRIPT_DIR=%~dp0
+echo %SCRIPT_DIR:~0,-1% 1>NUL 2>NUL
+set PYENV="%SCRIPT_DIR%\.pyenv"
+
 @REM Set python executable for your environment here
 set PY=python 
 
 @REM Python virtual environment
-%PY% -m venv .venv
-call .venv/Scripts/activate
+%PY% -m venv %PYENV%
+call %PYENV%\Scripts\activate
 
 @REM Install Python requirements
-%PY% -m pip install -r ../requirements.txt
+%PY% -m pip install -r requirements.txt
 
-git clone https://github.com/DroneCAN/DSDL
+rmdir /S /Q  %SCRIPT_DIR%\DSDL 1>NUL 2>NUL
+git clone https://github.com/DroneCAN/DSDL %SCRIPT_DIR%\DSDL
 
 echo "Testing generation"
-%PY% ../dronecan_dsdlc.py --output dsdl_generated DSDL/dronecan DSDL/uavcan DSDL/com DSDL/ardupilot 
+%PY% dronecan_dsdlc.py --output %SCRIPT_DIR%\dsdl_generated %SCRIPT_DIR%\DSDL\dronecan %SCRIPT_DIR%\DSDL\uavcan %SCRIPT_DIR%\DSDL\com %SCRIPT_DIR%\DSDL\ardupilot 
 
-@REM Python virtual environment
-call .venv/Scripts/deactivate

--- a/tests/test_windows.cmd
+++ b/tests/test_windows.cmd
@@ -1,8 +1,21 @@
-# simple test of DSDL compilation for windows
+@echo off
+@REM Simple test of DSDL compilation for windows
+@REM Tested on python 3.12.0
 
-python3 -m pip install -U empy pexpect dronecan
+@REM Set python executable for your environment here
+set PY=python 
+
+@REM Python virtual environment
+%PY% -m venv .venv
+call .venv/Scripts/activate
+
+@REM Install Python requirements
+%PY% -m pip install -r ../requirements.txt
 
 git clone https://github.com/DroneCAN/DSDL
 
 echo "Testing generation"
-python3 dronecan_dsdlc.py --output dsdl_generated DSDL/dronecan DSDL/uavcan DSDL/com DSDL/ardupilot 
+%PY% ../dronecan_dsdlc.py --output dsdl_generated DSDL/dronecan DSDL/uavcan DSDL/com DSDL/ardupilot 
+
+@REM Python virtual environment
+call .venv/Scripts/deactivate


### PR DESCRIPTION
The dependency on empy is broken. Resolve it by freezing the version of empy to 3.3.4. Other dependencies are also frozen at their current versions.
Some refinements to testing scripts have been made for better environmental compatibility.