### PR TITLE
Fix extra bracket generation in req.h file for static compound array fields

### DIFF
--- a/templates/msg.h.em
+++ b/templates/msg.h.em
@@ -266,7 +266,7 @@ bool _@(msg_underscored_name)_decode(const CanardRxTransfer* transfer, uint32_t*
 @[        end if]@
 @{indent -= 1}@{ind = '    '*indent}@
 @(ind)}
-@[              if field.type.value_type.category == field.type.value_type.CATEGORY_COMPOUND]@
+@[              if field.type.value_type.category == field.type.value_type.CATEGORY_COMPOUND and field.type.mode == field.type.MODE_DYNAMIC]@
 @{indent -= 1}@{ind = '    '*indent}@
 @(ind)}
 @[              end if]@


### PR DESCRIPTION
Fixed an edge case that occurred when a static, compound array field is used in a service invocation message. An extra bracket was being generated towards the end of the generated req.h file.