### PR TITLE
fix random_range_unsigned_value

### DIFF
--- a/templates/test_msg.cpp.em
+++ b/templates/test_msg.cpp.em
@@ -31,10 +31,10 @@ float random_float_val()
     return -512.0 + static_cast <float> (rand()) /( static_cast <float> (RAND_MAX/(1024.0)));
 }
 
-// Generate a random unsigned integer value from range
+// Generate a random unsigned integer value from range, inclusive
 uint32_t random_range_unsigned_val(uint32_t min, uint32_t max)
 {
-    return min + static_cast <uint32_t> (rand()) /( static_cast <uint32_t> (RAND_MAX/(max - min)));
+    return min + static_cast <uint32_t> (rand()) % (static_cast <uint32_t> (max - min + 1));
 }
 
 


### PR DESCRIPTION
Previously, it would in some circumstances not generate some values. In particular, dynamic arrays with 0 or 1 element were never tested with an element.

Now, all values can always be generated using the specified inclusive range (though the probabilities are not exactly identical).