### PR TITLE
Fix decoding of compound TAO elements

### DIFF
--- a/templates/msg.h.em
+++ b/templates/msg.h.em
@@ -225,7 +225,8 @@ bool _@(msg_underscored_name)_decode(const CanardRxTransfer* transfer, uint32_t*
 @(ind)if (tao) {
 @{indent += 1}@{ind = '    '*indent}@
 @(ind)msg->@(field.name).len = 0;
-@(ind)while ((transfer->payload_len*8) > *bit_ofs) {
+@(ind)uint32_t max_bits = (transfer->payload_len*8)-7; // TAO elements must be >= 8 bits
+@(ind)while (max_bits > *bit_ofs) {
 @{indent += 1}@{ind = '    '*indent}@
 @(ind)if (_@(underscored_name(field.type.value_type))_decode(transfer, bit_ofs, &msg->@(field_get_data(field))[msg->@(field.name).len], @[if field == msg_fields[-1] and field.type.value_type.get_min_bitlen() < 8]tao && i==msg->@(field.name).len@[else]false@[end if]@)) {return true;}
 @(ind)msg->@(field.name).len++;


### PR DESCRIPTION
Previously, if any bits were left, the loop would try to decode another element. However, elements of arrays eligible for TAO must be >= 8 bits, so the decode would over-run by an element if 7 or fewer bits were left and the decode would fail due to the length check.

Fix this by only decoding until there are 7 or fewer bits left.

Not triggered by any message in the DSDL repo, but it is easy to create one which would be incorrectly decoded, e.g.

```
void1 pad
uavcan.equipment.gnss.Fix2 fix
```