### PR TITLE
validate received length when decoding arrays using TAO

### DIFF
--- a/templates/msg.h.em
+++ b/templates/msg.h.em
@@ -225,10 +225,11 @@ bool _@(msg_underscored_name)_decode(const CanardRxTransfer* transfer, uint32_t*
 @(ind)if (tao) {
 @{indent += 1}@{ind = '    '*indent}@
 @(ind)msg->@(field.name).len = 0;
+@(ind)size_t max_len = @(field.type.max_size);
 @(ind)uint32_t max_bits = (transfer->payload_len*8)-7; // TAO elements must be >= 8 bits
 @(ind)while (max_bits > *bit_ofs) {
 @{indent += 1}@{ind = '    '*indent}@
-@(ind)if (_@(underscored_name(field.type.value_type))_decode(transfer, bit_ofs, &msg->@(field_get_data(field))[msg->@(field.name).len], @[if field == msg_fields[-1] and field.type.value_type.get_min_bitlen() < 8]tao && i==msg->@(field.name).len@[else]false@[end if]@)) {return true;}
+@(ind)if (!max_len-- || _@(underscored_name(field.type.value_type))_decode(transfer, bit_ofs, &msg->@(field_get_data(field))[msg->@(field.name).len], @[if field == msg_fields[-1] and field.type.value_type.get_min_bitlen() < 8]tao && i==msg->@(field.name).len@[else]false@[end if]@)) {return true;}
 @(ind)msg->@(field.name).len++;
 @{indent -= 1}@{ind = '    '*indent}@
 @(ind)}


### PR DESCRIPTION
Avoids overrunning the receive array and corrupting memory.