### PR TITLE
test_msg: remove redundant packet buffer initialization

### DIFF
--- a/templates/test_msg.cpp.em
+++ b/templates/test_msg.cpp.em
@@ -89,7 +89,7 @@ int main() {
     // Create a UAVCAN message
     @(msg_underscored_name) _msg = sample_@(msg_underscored_name)_msg();
 
-    uint8_t buffer[@(msg_define_name.upper())_MAX_SIZE] {};
+    uint8_t buffer[@(msg_define_name.upper())_MAX_SIZE];
 
     // encode the message
     uint32_t data_len = @(msg_underscored_name)_encode(&_msg, buffer);


### PR DESCRIPTION
The `<msg>_encode` function always zeros the buffer up to `<msg>_MAX_SIZE` bytes so there is no need to do it beforehand.

Avoids encouraging poor habits.

Verified that the tests work reliably still.