### PR TITLE
.github: use latest actions/upload-artifact instead of disabled version

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
           tests/test_linux.sh
 
       - name: Archive generated headers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dsdl_generated
           path: dsdl_generated

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -13,7 +13,7 @@ jobs:
           tests/test_windows.cmd
 
       - name: Archive generated headers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dsdl_generated
           path: dsdl_generated


### PR DESCRIPTION
Fixes CI failure.