### PR TITLE
Fix misleading error message when pkg_resources is missing

### DIFF
--- a/dronecan_dsdlc.py
+++ b/dronecan_dsdlc.py
@@ -22,7 +22,10 @@ except Exception as ex:
         import dronecan.dsdl
     except Exception as ex:
         print(ex)
-        print("Failed to import dronecan.dsdl, please install dronecan with 'python3 -m pip install dronecan'")
+        if "pkg_resources" in str(ex):
+            print("Failed to import pkg_resources, please install setuptools with 'python3 -m pip install setuptools'")
+        else:
+            print("Failed to import dronecan.dsdl, please install dronecan with 'python3 -m pip install dronecan'")
         sys.exit(1)
 
 from dronecan_dsdlc_helpers import *


### PR DESCRIPTION
## Problem

When `pkg_resources` (from `setuptools`) is missing, the build system shows:
No module named 'pkg_resources'
Failed to import dronecan.dsdl, please install dronecan with 'python3 -m pip install dronecan'


This is misleading because:
- `dronecan` might already be installed
- The actual missing dependency is `pkg_resources` (from `setuptools`)
- Users waste time reinstalling `dronecan` when they need `setuptools`

**Related issue:** ArduPilot/ardupilot#31385

## Solution

Added error message differentiation to check if `pkg_resources` is mentioned in the exception:
- If `pkg_resources` is in error → suggest installing `setuptools`
- Otherwise: suggest installing `dronecan`

## Changes Made

Modified the exception handler in `dronecan_dsdlc.py` (lines 22-27) to:
```python
if "pkg_resources" in str(ex):
    print("Failed to import pkg_resources, please install setuptools with 'python3 -m pip install setuptools'")
else:
    print("Failed to import dronecan.dsdl, please install dronecan with 'python3 -m pip install dronecan'")