### PR TITLE
fix error with Python 3.14 on Linux

### DIFF
--- a/dronecan_dsdlc.py
+++ b/dronecan_dsdlc.py
@@ -13,6 +13,19 @@ import em
 import shutil
 import time
 
+if __name__ == '__main__':
+    import multiprocessing
+
+    default_method = multiprocessing.get_all_start_methods()[0]
+    # we are not compatible with forkserver because we trust argv to be set up
+    # during module import, which using forkserver it is not in Python 3.13 and
+    # later. as Python 3.14 and later make forkserver the default on Linux, we
+    # need to switch back to the previous default of fork until we fix our code
+    # to not run stuff on import.
+    if default_method == "forkserver":
+        default_method = "fork"
+    multiprocessing.set_start_method(default_method)
+
 try:
     import dronecan.dsdl
 except Exception as ex:


### PR DESCRIPTION
Python 3.14 switches to multiprocessing start method `forkserver` on Linux, which our code is broken with due to changes in Python 3.13 and our bad habit of running code in the main module.

This causes our compile/test subprocesses to die, saying `dronecan_dsdlc.py: error: the following arguments are required: namespace_dir` and ultimately failing with `ConnectionResetError: [Errno 104] Connection reset by peer`.

Fix by switching back to the old default of `fork` if we are going to use the broken `forkserver`. Our code needs to be fixed in the future to not do so much in the main module as `fork` is not the recommened method, though we probably do not fall afoul of its flaws.

Tested on Linux with Python 3.14, 3.13, and 3.12 that AP compiles after this fix, where previously it did not on 3.14. Also confirmed compilation result is the same.