### PR TITLE
Use fork start method for DSDL generation pool

### DIFF
--- a/dronecan_dsdlc.py
+++ b/dronecan_dsdlc.py
@@ -17,6 +17,7 @@ if __name__ == '__main__':
     import multiprocessing
 
     default_method = multiprocessing.get_all_start_methods()[0]
+
     # we are not compatible with forkserver because we trust argv to be set up
     # during module import, which using forkserver it is not in Python 3.13 and
     # later. as Python 3.14 and later make forkserver the default on Linux, we
@@ -24,6 +25,15 @@ if __name__ == '__main__':
     # to not run stuff on import.
     if default_method == "forkserver":
         default_method = "fork"
+
+    # On macOS the default is 'spawn', which re-exec's the Python
+    # interpreter for every worker; each fresh exec triggers a macOS
+    # Gatekeeper/xprotectd malware scan, and a pool sized to all CPU cores
+    # produces a scan storm that pegs xprotectd at 100% CPU and stalls the
+    # build. 'fork' shares the already-scanned parent image and avoids it.
+    if sys.platform == "darwin":
+        default_method = "fork"
+
     multiprocessing.set_start_method(default_method)
 
 try:


### PR DESCRIPTION
On macOS the default multiprocessing start method is 'spawn', which re-exec's the Python interpreter for every worker. Each fresh exec triggers a Gatekeeper/xprotectd malware scan, and a pool sized to all CPU cores produces a scan storm that pegs xprotectd at 100% CPU and stalls the build (e.g. during `./waf copter`).

Use the 'fork' start method when available (the Linux default), which shares the already-scanned parent image and avoids the spawn storm. Falls back to the platform default where fork is unavailable (Windows).